### PR TITLE
Use Node's btoa implementation

### DIFF
--- a/tests/unit/helpers/index.ts
+++ b/tests/unit/helpers/index.ts
@@ -25,7 +25,6 @@ export function setupGlobals(test: Test) {
     const { Headers, Response } = fetch;
     globalThis.Headers ??= Headers;
     globalThis.Response ??= Response;
-    globalThis.btoa ??= (s: string) => Buffer.from(s, 'binary').toString('base64');
   });
 }
 


### PR DESCRIPTION
Refs #45

This PR removes the mock implementation of `btoa` used in the tests now that Node has a proper implementation.